### PR TITLE
Add a patch to extract mappings for further use by legacydev

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -30,12 +30,15 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository.MetadataSources;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -361,27 +364,34 @@ public class UserDevPlugin implements Plugin<Project> {
      * Each quirk is documented and accounted for in this function.
      *  - Classpath / Resources; FG2 Userdev puts all classes and resources into a single jar file for FML to consume.
      *      FG3+ puts classes and resources into separate folders, which breaks on older versions.
-     *      We replicate the FG2 behavior by replacing these folders by the jar artifact on the runtime classpath.
+     *      We replicate the FG2 behavior by forcing the classes and resources to go to the same build folder.
      *
      * In other words, it's a containment zone for version-specific hacks.
      * For issues you think are caused by this function, contact Curle or any other Retrogradle maintainer.
      */
     private void runRetrogradleFixes(Project project) {
         final LegacyExtension config = (LegacyExtension) project.getExtensions().getByName(LegacyExtension.EXTENSION_NAME);
-        final boolean shouldFixClasspath = config.getFixClasspath().get();
-        
+        final boolean shouldFixClasspath = config.getFixClasspath();
+
         if(shouldFixClasspath) {
-            // get the minecraft extension
-            final MinecraftExtension minecraft = project.getExtensions().getByType(MinecraftExtension.class);
-            // create a singleton collection from the jar task's output 
-            final FileCollection jar = project.files(project.getTasks().named("jar"));
-            
-            minecraft.getRuns().stream()
-                // get all RunConfig SourceSets
-                .flatMap(runConfig -> runConfig.getAllSources().stream())
-                .distinct()
-                // replace output directories with the jar artifact on each SourceSet's classpath
-                .forEach(sourceSet -> sourceSet.setRuntimeClasspath(sourceSet.getRuntimeClasspath().minus(sourceSet.getOutput()).plus(jar)));
+            // Find the output jar file
+            final Jar jarTask = (Jar) project.getTasks().getByName("jar");
+            // Get the classpath and create a composite with the found jar file
+            final ConfigurableFileCollection classpath = project.files(
+                    project.getConfigurations().getByName("runtimeClasspath"),
+                    jarTask.getArchiveFile().get().getAsFile());
+            // Get the Userdev plugin for the run configs
+            final MinecraftExtension minecraftExtension = (MinecraftExtension) project.getExtensions().getByName(UserDevExtension.EXTENSION_NAME);
+
+            // For all defined run configurations..
+            minecraftExtension.getRuns().stream()
+                    // Get the Task created by it
+                    .map(run -> project.getTasks().getByName(run.getTaskName()))
+                    // Filter for those that define a JavaExec run
+                    .filter(task -> task instanceof JavaExec)
+                    // Set the run's classpath to the composite we made
+                    .forEach(task -> ((JavaExec) task).setClasspath(classpath));
         }
+
     }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/legacy/LegacyExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/legacy/LegacyExtension.java
@@ -4,7 +4,6 @@ import groovy.lang.GroovyObjectSupport;
 import net.minecraftforge.gradle.userdev.UserDevPlugin;
 import net.minecraftforge.srgutils.MinecraftVersion;
 import org.gradle.api.Project;
-import org.gradle.api.provider.Property;
 
 
 /**
@@ -17,30 +16,36 @@ import org.gradle.api.provider.Property;
  *
  * It allows for configuring RetroGradle patches and fixes, which are otherwise set by version.
  * Each fix is documented in this class and in the application function.
- * {@link UserDevPlugin#runRetrogradleFixes}
+ * {@link UserDevPlugin#runRetrogradleFixes()}
  *
  * @author Curle
  */
-public abstract class LegacyExtension extends GroovyObjectSupport {
+public class LegacyExtension extends GroovyObjectSupport {
     public static final String EXTENSION_NAME = "legacy";
-    private static final MinecraftVersion FG3 = MinecraftVersion.from("1.13");
 
     public LegacyExtension(Project project) {
-        getFixClasspath().convention(project.provider(() -> {
-            final MinecraftVersion version = MinecraftVersion.from((String) project.getExtensions().getExtraProperties().get("MC_VERSION"));
-            
-            // fixClasspath by default if version is below FG 3
-            return version.compareTo(FG3) < 0;
-        }));
+        final MinecraftVersion version = MinecraftVersion.from((String) project.getExtensions().getExtraProperties().get("MC_VER"));
+        final MinecraftVersion FG2_3 = MinecraftVersion.from("1.12.2");
+
+        // fixClasspath by default if version is below FG 2.3
+        fixClasspath = version.compareTo(FG2_3) < 0;
     }
 
     /**
      * fixClassPath;
      *  FG2 Userdev puts all classes and resources into a single jar file for FML to consume.
      *  FG3+ puts classes and resources into separate folders, which breaks on older versions.
-     *  We replicate the FG2 behavior by replacing these folders by the jar artifact on the runtime classpath.
+     *  We replicate the FG2 behavior by forcing the classes and resources to go to the same build folder.
      *
      * Takes a boolean - true for apply fix, false for no fix.
      */
-    public abstract Property<Boolean> getFixClasspath();
+    private boolean fixClasspath;
+
+    // fixClasspath Getter and buildscript integration.
+    public boolean getFixClasspath() { return fixClasspath; }
+
+    // fixClasspath Setter
+    public void setFixClasspath(boolean shouldFix) {
+        fixClasspath = shouldFix;
+    }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/legacy/LegacyExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/legacy/LegacyExtension.java
@@ -4,6 +4,8 @@ import groovy.lang.GroovyObjectSupport;
 import net.minecraftforge.gradle.userdev.UserDevPlugin;
 import net.minecraftforge.srgutils.MinecraftVersion;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 
 
 /**
@@ -16,36 +18,44 @@ import org.gradle.api.Project;
  *
  * It allows for configuring RetroGradle patches and fixes, which are otherwise set by version.
  * Each fix is documented in this class and in the application function.
- * {@link UserDevPlugin#runRetrogradleFixes()}
+ * {@link UserDevPlugin#runRetrogradleFixes}
  *
  * @author Curle
  */
-public class LegacyExtension extends GroovyObjectSupport {
+public abstract class LegacyExtension extends GroovyObjectSupport {
     public static final String EXTENSION_NAME = "legacy";
+    private static final MinecraftVersion FG3 = MinecraftVersion.from("1.13");
 
     public LegacyExtension(Project project) {
-        final MinecraftVersion version = MinecraftVersion.from((String) project.getExtensions().getExtraProperties().get("MC_VER"));
-        final MinecraftVersion FG2_3 = MinecraftVersion.from("1.12.2");
-
-        // fixClasspath by default if version is below FG 2.3
-        fixClasspath = version.compareTo(FG2_3) < 0;
+        Provider<Boolean> isLegacy = project.provider(() -> {
+            final MinecraftVersion version = MinecraftVersion.from((String) project.getExtensions().getExtraProperties().get("MC_VERSION"));
+            
+            // enable patches by default if version is below FG 3
+            return version.compareTo(FG3) < 0;
+        });
+        
+        getFixClasspath().convention(isLegacy);
+        getExtractMappings().convention(isLegacy);
     }
 
     /**
      * fixClassPath;
      *  FG2 Userdev puts all classes and resources into a single jar file for FML to consume.
      *  FG3+ puts classes and resources into separate folders, which breaks on older versions.
-     *  We replicate the FG2 behavior by forcing the classes and resources to go to the same build folder.
+     *  We replicate the FG2 behavior by replacing these folders by the jar artifact on the runtime classpath.
      *
      * Takes a boolean - true for apply fix, false for no fix.
      */
-    private boolean fixClasspath;
+    public abstract Property<Boolean> getFixClasspath();
 
-    // fixClasspath Getter and buildscript integration.
-    public boolean getFixClasspath() { return fixClasspath; }
-
-    // fixClasspath Setter
-    public void setFixClasspath(boolean shouldFix) {
-        fixClasspath = shouldFix;
-    }
+    /**
+     * extractMappings;
+     * FG2 GradleStart exposes a <code>net.minecraftforge.gradle.GradleStart.csvDir</code> property
+     * that points to a directory containing CSV mappings files. This is used by LegacyDev to remap dependencies' AT modifiers.
+     * We replicate the FG2 behavior by extracting the mappings to a folder in the build directory
+     * and setting the property to point to it.
+     * <p>
+     * Takes a boolean - true for apply fix, false for no fix.
+     */
+    public abstract Property<Boolean> getExtractMappings();
 }


### PR DESCRIPTION
### Extract mappings patch

FG2 GradleStart exposes a `net.minecraftforge.gradle.GradleStart.csvDir` property that points to a directory containing CSV mappings files. This is used by LegacyDev to remap dependencies' AT modifiers (See [`AccessTransformerTransformer`](https://github.com/Su5eD/LegacyDev/blob/91d43ca56bde9490fc76b50dd1d6d16e30884f1f/src/main/java/net/minecraftforge/gradle/GradleForgeHacks.java#L176)).

We replicate FG2 behavior by extracting the mappings to a folder in the build directory, then setting the property that points to it on all minecraft `RunConfig`s.

### See also
- https://github.com/RetroGradle/LegacyDev/pull/1